### PR TITLE
Feature to poll mouse position, fix build on aarch64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,11 @@ save = ["dep:image"]
 
 shm = []
 xrandr = []
+mouse = []
 
 [dependencies]
 image = { version = "^0.23", optional = true }
 libc = "0.2"
 
 [package.metadata.docs.rs]
-features = [ "xrandr", "shm" ]
+features = [ "xrandr", "shm", "mouse" ]

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -11,3 +11,7 @@ pub use shm::*;
 
 #[cfg(feature = "xrandr")]
 pub mod xrandr;
+
+#[cfg(feature = "mouse")]
+pub mod mouse;
+

--- a/src/ffi/mouse.rs
+++ b/src/ffi/mouse.rs
@@ -1,4 +1,4 @@
-use std::os::raw::{c_char, c_int, c_uint, c_ulong};
+use std::os::raw::{c_int, c_uint};
 
 use crate::ffi::*;
 

--- a/src/ffi/mouse.rs
+++ b/src/ffi/mouse.rs
@@ -1,0 +1,17 @@
+use std::os::raw::{c_char, c_int, c_uint, c_ulong};
+
+use crate::ffi::*;
+
+extern "C" {
+    pub fn XQueryPointer(
+        display: XDisplay,
+        w: XWindow,
+        root_return: *const XWindow,
+        child_return: *const XWindow,
+        root_x_return: *const c_int,
+        root_y_return: *const c_int,
+        win_x_return: *const c_int,
+        win_y_return: *const c_int,
+        mask_return: *const c_uint,
+    ) -> c_int;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 
 
 
-use std::ffi::CString;
+use std::ffi::{CString, c_char};
 
 pub mod ffi;
 pub use ffi::{Rgb8, Bgr8};
@@ -181,7 +181,7 @@ impl Display {
 impl Image {
     pub unsafe fn from_raw_parts(display: &Display, data: *const u8, width: u32, height: u32) -> Self {
         let visual = XDefaultVisual(display.connection, 0);
-        let ximg = XCreateImage(display.connection, visual, 24, ZPixmap as i32, 0, data as *const i8, width, height, 32, 0);
+        let ximg = XCreateImage(display.connection, visual, 24, ZPixmap as i32, 0, data as *const c_char, width, height, 32, 0);
         // TODO: check ximg for null-ptr
         Self {
             raw: ximg
@@ -235,7 +235,7 @@ impl Image {
             let img_size = (width * height * (32 / 8)) as usize;
             let data = libc::malloc(img_size);
 
-            let ximg = XCreateImage(display.connection, visual, 24, ZPixmap as i32, 0, data as *const i8, width, height, 32, 0);
+            let ximg = XCreateImage(display.connection, visual, 24, ZPixmap as i32, 0, data as *const c_char, width, height, 32, 0);
             Self {
                 raw: ximg
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,9 @@ pub mod monitor;
 #[cfg(feature = "shm")]
 pub mod shm;
 
+#[cfg(feature = "mouse")]
+pub mod mouse;
+
 use ffi::{*, constants::{AllPlanes, ZPixmap}};
 
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -90,4 +90,15 @@ impl Monitor {
     pub fn primary(&self) -> bool {
         self.primary
     }
+
+    #[cfg(feature = "mouse")]
+    /// Translates a position from display.root_mouse_position) to a position relative to the monitor
+    pub fn mouse_to_local(&self, root_pos: (i32, i32)) -> Option<(i32, i32)> {
+        let local_pos = (root_pos.0 - self.x, root_pos.1 - self.y);
+        if local_pos.0 >= 0 && local_pos.0 <= self.width && local_pos.1 >= 0 && local_pos.1 <= self.height {
+            Some(local_pos)
+        } else {
+            None
+        }
+    }
 }

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -1,0 +1,48 @@
+use crate::Display;
+
+impl Display {
+    #[cfg(feature = "xrandr")]
+    /// Query the mouse position relative to the root window
+    /// ```rust
+    /// # use rxscreen::Display;
+    /// if let Ok(display) = Display::new(":0.0") {
+    ///    let Some((mouse_x, mouse_y)) = display.root_mouse_position() else {
+    ///         println!("Failed to get mouse position");
+    ///    }
+    ///    println!("Mouse Pos: {}, {}", mouse_x, mouse_y);
+    /// }
+    pub fn root_mouse_position(&self) -> Option<(i32, i32)> {
+        use crate::ffi::{mouse::XQueryPointer, XWindow};
+        use std::ffi::{c_int, c_uint};
+        unsafe {
+            let mut root: XWindow = 0;
+            let mut child: XWindow = 0;
+
+            let mut root_x: c_int = 0;
+            let mut root_y: c_int = 0;
+
+            let mut win_x: c_int = 0;
+            let mut win_y: c_int = 0;
+
+            let mut mask: c_uint = 0;
+
+            let code = XQueryPointer(
+                self.connection,
+                self.window,
+                &mut root,
+                &mut child,
+                &mut root_x,
+                &mut root_y,
+                &mut win_x,
+                &mut win_y,
+                &mut mask,
+            );
+
+            if code != 0 {
+                Some((root_x, root_y))
+            } else {
+                None
+            }
+        }
+    }
+}

--- a/src/shm.rs
+++ b/src/shm.rs
@@ -31,7 +31,6 @@
 
 
 use crate::{Display, Image, ffi::{*, constants::*}};
-use std::ops::Deref;
 use std::pin::Pin;
 
 #[derive(PartialEq, Debug)]
@@ -149,7 +148,7 @@ impl<'a> ShmBuilder<'a> {
                 //libc::memset(shminfo as *mut c_void, 0, std::mem::size_of::<XShmSegmentInfo>());
                 let mut shminfo = Box::pin(XShmSegmentInfo { shmseg: 0, shmid: 0, shmaddr: std::ptr::null(), read_only: 0});
 
-                let mut ximg = XShmCreateImage(self.display.connection, vis, (*vis).bits_per_rgb as u32, ZPixmap as i32, std::ptr::null(), shminfo.as_ref().get_ref(), self.area.0, self.area.1) as *mut XImage;
+                let ximg = XShmCreateImage(self.display.connection, vis, (*vis).bits_per_rgb as u32, ZPixmap as i32, std::ptr::null(), shminfo.as_ref().get_ref(), self.area.0, self.area.1) as *mut XImage;
 
                 shminfo.shmid = shmget(IPC_PRIVATE, ((*ximg).bytes_per_line * (*ximg).height) as usize, IPC_CREAT|0o600);
                 if shminfo.shmid == -1 {

--- a/src/shm.rs
+++ b/src/shm.rs
@@ -139,7 +139,7 @@ impl<'a> ShmBuilder<'a> {
         unsafe {
             use libc::{shmget, shmat};
             use libc::{IPC_PRIVATE, IPC_CREAT};
-            use libc::c_void;
+            use libc::{c_char, c_void};
 
             if XShmQueryExtension(self.display.connection) {
                 let vis = XDefaultVisual(self.display.connection, 0);
@@ -155,7 +155,7 @@ impl<'a> ShmBuilder<'a> {
                     return Err(ShmError::ShmInitFailed);
                 }
 
-                let memory_addr = shmat((*shminfo).shmid, 0 as *const c_void, 0) as *mut i8;
+                let memory_addr = shmat((*shminfo).shmid, 0 as *const c_void, 0) as *mut c_char;
                 shminfo.shmaddr = memory_addr;
                 (*ximg).data = memory_addr;
                 shminfo.read_only = 0;


### PR DESCRIPTION
New `mouse` feature that adds 2 methods:

`Display::root_mouse_position()`
`Monitor::mouse_to_local()`

Example usage to get screen-local mouse coords:

```rust
Display d;
Monitor m;

let Some(root_pos) = d.root_mouse_position() else {
    continue;
};
let Some((x, y)) = m.mouse_to_local(root_pos) else {
    continue;
};
```

We've thrown in as extra a compile fix on aarch64. The issue there was that `i8` was being used instead of `c_char`. (`c_char` is `u8` on aarch64, `i8` on amd64) Thanks to @scrumplex for this.