### PR TITLE
Use core::ffi for C types

### DIFF
--- a/src/ffi/events.rs
+++ b/src/ffi/events.rs
@@ -1,3 +1,4 @@
+use core::ffi::{c_char, c_int, c_long, c_short, c_uchar, c_uint, c_ulong, c_void};
 use super::{XDisplay, XWindow, Time, Drawable, Atom, Colormap, XID};
 
 pub const KeyPress: u32 = 2;
@@ -39,61 +40,61 @@ pub const LASTEvent: u32 = 36;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XKeyEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub window: XWindow,
     pub root: XWindow,
     pub subwindow: XWindow,
     pub time: Time,
-    pub x: ::std::os::raw::c_int,
-    pub y: ::std::os::raw::c_int,
-    pub x_root: ::std::os::raw::c_int,
-    pub y_root: ::std::os::raw::c_int,
-    pub state: ::std::os::raw::c_uint,
-    pub keycode: ::std::os::raw::c_uint,
-    pub same_screen: ::std::os::raw::c_int,
+    pub x: c_int,
+    pub y: c_int,
+    pub x_root: c_int,
+    pub y_root: c_int,
+    pub state: c_uint,
+    pub keycode: c_uint,
+    pub same_screen: c_int,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XButtonEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub window: XWindow,
     pub root: XWindow,
     pub subwindow: XWindow,
     pub time: Time,
-    pub x: ::std::os::raw::c_int,
-    pub y: ::std::os::raw::c_int,
-    pub x_root: ::std::os::raw::c_int,
-    pub y_root: ::std::os::raw::c_int,
-    pub state: ::std::os::raw::c_uint,
-    pub button: ::std::os::raw::c_uint,
-    pub same_screen: ::std::os::raw::c_int,
+    pub x: c_int,
+    pub y: c_int,
+    pub x_root: c_int,
+    pub y_root: c_int,
+    pub state: c_uint,
+    pub button: c_uint,
+    pub same_screen: c_int,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XMotionEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub window: XWindow,
     pub root: XWindow,
     pub subwindow: XWindow,
     pub time: Time,
-    pub x: ::std::os::raw::c_int,
-    pub y: ::std::os::raw::c_int,
-    pub x_root: ::std::os::raw::c_int,
-    pub y_root: ::std::os::raw::c_int,
-    pub state: ::std::os::raw::c_uint,
-    pub is_hint: ::std::os::raw::c_char,
-    pub same_screen: ::std::os::raw::c_int,
+    pub x: c_int,
+    pub y: c_int,
+    pub x_root: c_int,
+    pub y_root: c_int,
+    pub state: c_uint,
+    pub is_hint: c_char,
+    pub same_screen: c_int,
 }
 
 
@@ -101,47 +102,47 @@ pub struct XMotionEvent {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XCrossingEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub window: XWindow,
     pub root: XWindow,
     pub subwindow: XWindow,
     pub time: Time,
-    pub x: ::std::os::raw::c_int,
-    pub y: ::std::os::raw::c_int,
-    pub x_root: ::std::os::raw::c_int,
-    pub y_root: ::std::os::raw::c_int,
-    pub mode: ::std::os::raw::c_int,
-    pub detail: ::std::os::raw::c_int,
-    pub same_screen: ::std::os::raw::c_int,
-    pub focus: ::std::os::raw::c_int,
-    pub state: ::std::os::raw::c_uint,
+    pub x: c_int,
+    pub y: c_int,
+    pub x_root: c_int,
+    pub y_root: c_int,
+    pub mode: c_int,
+    pub detail: c_int,
+    pub same_screen: c_int,
+    pub focus: c_int,
+    pub state: c_uint,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XFocusChangeEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub window: XWindow,
-    pub mode: ::std::os::raw::c_int,
-    pub detail: ::std::os::raw::c_int,
+    pub mode: c_int,
+    pub detail: c_int,
 }
 
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XKeymapEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub window: XWindow,
-    pub key_vector: [::std::os::raw::c_char; 32usize],
+    pub key_vector: [c_char; 32usize],
 }
 
 
@@ -149,85 +150,85 @@ pub struct XKeymapEvent {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XExposeEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub window: XWindow,
-    pub x: ::std::os::raw::c_int,
-    pub y: ::std::os::raw::c_int,
-    pub width: ::std::os::raw::c_int,
-    pub height: ::std::os::raw::c_int,
-    pub count: ::std::os::raw::c_int,
+    pub x: c_int,
+    pub y: c_int,
+    pub width: c_int,
+    pub height: c_int,
+    pub count: c_int,
 }
 
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XGraphicsExposeEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub drawable: Drawable,
-    pub x: ::std::os::raw::c_int,
-    pub y: ::std::os::raw::c_int,
-    pub width: ::std::os::raw::c_int,
-    pub height: ::std::os::raw::c_int,
-    pub count: ::std::os::raw::c_int,
-    pub major_code: ::std::os::raw::c_int,
-    pub minor_code: ::std::os::raw::c_int,
+    pub x: c_int,
+    pub y: c_int,
+    pub width: c_int,
+    pub height: c_int,
+    pub count: c_int,
+    pub major_code: c_int,
+    pub minor_code: c_int,
 }
 
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XNoExposeEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub drawable: Drawable,
-    pub major_code: ::std::os::raw::c_int,
-    pub minor_code: ::std::os::raw::c_int,
+    pub major_code: c_int,
+    pub minor_code: c_int,
 }
 
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XVisibilityEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub window: XWindow,
-    pub state: ::std::os::raw::c_int,
+    pub state: c_int,
 }
 
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XCreateWindowEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub parent: XWindow,
     pub window: XWindow,
-    pub x: ::std::os::raw::c_int,
-    pub y: ::std::os::raw::c_int,
-    pub width: ::std::os::raw::c_int,
-    pub height: ::std::os::raw::c_int,
-    pub border_width: ::std::os::raw::c_int,
-    pub override_redirect: ::std::os::raw::c_int,
+    pub x: c_int,
+    pub y: c_int,
+    pub width: c_int,
+    pub height: c_int,
+    pub border_width: c_int,
+    pub override_redirect: c_int,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XDestroyWindowEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub event: XWindow,
     pub window: XWindow,
@@ -236,33 +237,33 @@ pub struct XDestroyWindowEvent {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XUnmapEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub event: XWindow,
     pub window: XWindow,
-    pub from_configure: ::std::os::raw::c_int,
+    pub from_configure: c_int,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XMapEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub event: XWindow,
     pub window: XWindow,
-    pub override_redirect: ::std::os::raw::c_int,
+    pub override_redirect: c_int,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XMapRequestEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub parent: XWindow,
     pub window: XWindow,
@@ -271,123 +272,123 @@ pub struct XMapRequestEvent {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XReparentEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub event: XWindow,
     pub window: XWindow,
     pub parent: XWindow,
-    pub x: ::std::os::raw::c_int,
-    pub y: ::std::os::raw::c_int,
-    pub override_redirect: ::std::os::raw::c_int,
+    pub x: c_int,
+    pub y: c_int,
+    pub override_redirect: c_int,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XConfigureEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub event: XWindow,
     pub window: XWindow,
-    pub x: ::std::os::raw::c_int,
-    pub y: ::std::os::raw::c_int,
-    pub width: ::std::os::raw::c_int,
-    pub height: ::std::os::raw::c_int,
-    pub border_width: ::std::os::raw::c_int,
+    pub x: c_int,
+    pub y: c_int,
+    pub width: c_int,
+    pub height: c_int,
+    pub border_width: c_int,
     pub above: XWindow,
-    pub override_redirect: ::std::os::raw::c_int,
+    pub override_redirect: c_int,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XGravityEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub event: XWindow,
     pub window: XWindow,
-    pub x: ::std::os::raw::c_int,
-    pub y: ::std::os::raw::c_int,
+    pub x: c_int,
+    pub y: c_int,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XResizeRequestEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub window: XWindow,
-    pub width: ::std::os::raw::c_int,
-    pub height: ::std::os::raw::c_int,
+    pub width: c_int,
+    pub height: c_int,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XConfigureRequestEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub parent: XWindow,
     pub window: XWindow,
-    pub x: ::std::os::raw::c_int,
-    pub y: ::std::os::raw::c_int,
-    pub width: ::std::os::raw::c_int,
-    pub height: ::std::os::raw::c_int,
-    pub border_width: ::std::os::raw::c_int,
+    pub x: c_int,
+    pub y: c_int,
+    pub width: c_int,
+    pub height: c_int,
+    pub border_width: c_int,
     pub above: XWindow,
-    pub detail: ::std::os::raw::c_int,
-    pub value_mask: ::std::os::raw::c_ulong,
+    pub detail: c_int,
+    pub value_mask: c_ulong,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XCirculateEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub event: XWindow,
     pub window: XWindow,
-    pub place: ::std::os::raw::c_int,
+    pub place: c_int,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XCirculateRequestEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub parent: XWindow,
     pub window: XWindow,
-    pub place: ::std::os::raw::c_int,
+    pub place: c_int,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XPropertyEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub window: XWindow,
     pub atom: Atom,
     pub time: Time,
-    pub state: ::std::os::raw::c_int,
+    pub state: c_int,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XSelectionClearEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub window: XWindow,
     pub selection: Atom,
@@ -398,9 +399,9 @@ pub struct XSelectionClearEvent {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XSelectionRequestEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub owner: XWindow,
     pub requestor: XWindow,
@@ -413,9 +414,9 @@ pub struct XSelectionRequestEvent {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XSelectionEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub requestor: XWindow,
     pub selection: Atom,
@@ -427,68 +428,68 @@ pub struct XSelectionEvent {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XColormapEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub window: XWindow,
     pub colormap: Colormap,
-    pub new: ::std::os::raw::c_int,
-    pub state: ::std::os::raw::c_int,
+    pub new: c_int,
+    pub state: c_int,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union XClientMessageEvent__bindgen_ty_1 {
-    pub b: [::std::os::raw::c_char; 20usize],
-    pub s: [::std::os::raw::c_short; 10usize],
-    pub l: [::std::os::raw::c_long; 5usize],
+    pub b: [c_char; 20usize],
+    pub s: [c_short; 10usize],
+    pub l: [c_long; 5usize],
 }
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct XClientMessageEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub window: XWindow,
     pub message_type: Atom,
-    pub format: ::std::os::raw::c_int,
+    pub format: c_int,
     pub data: XClientMessageEvent__bindgen_ty_1,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XMappingEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub window: XWindow,
-    pub request: ::std::os::raw::c_int,
-    pub first_keycode: ::std::os::raw::c_int,
-    pub count: ::std::os::raw::c_int,
+    pub request: c_int,
+    pub first_keycode: c_int,
+    pub count: c_int,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XErrorEvent {
-    pub type_: ::std::os::raw::c_int,
+    pub type_: c_int,
     pub display: *mut XDisplay,
     pub resourceid: XID,
-    pub serial: ::std::os::raw::c_ulong,
-    pub error_code: ::std::os::raw::c_uchar,
-    pub request_code: ::std::os::raw::c_uchar,
-    pub minor_code: ::std::os::raw::c_uchar,
+    pub serial: c_ulong,
+    pub error_code: c_uchar,
+    pub request_code: c_uchar,
+    pub minor_code: c_uchar,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XAnyEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
     pub window: XWindow,
 }
@@ -496,31 +497,31 @@ pub struct XAnyEvent {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XGenericEvent {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
-    pub extension: ::std::os::raw::c_int,
-    pub evtype: ::std::os::raw::c_int,
+    pub extension: c_int,
+    pub evtype: c_int,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XGenericEventCookie {
-    pub type_: ::std::os::raw::c_int,
-    pub serial: ::std::os::raw::c_ulong,
-    pub send_event: ::std::os::raw::c_int,
+    pub type_: c_int,
+    pub serial: c_ulong,
+    pub send_event: c_int,
     pub display: *mut XDisplay,
-    pub extension: ::std::os::raw::c_int,
-    pub evtype: ::std::os::raw::c_int,
-    pub cookie: ::std::os::raw::c_uint,
-    pub data: *mut ::std::os::raw::c_void,
+    pub extension: c_int,
+    pub evtype: c_int,
+    pub cookie: c_uint,
+    pub data: *mut c_void,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union XEvent {
-    pub r#type: ::std::os::raw::c_int,
+    pub r#type: c_int,
     pub xany: XAnyEvent,
     pub xkey: XKeyEvent,
     pub xbutton: XButtonEvent,
@@ -554,5 +555,5 @@ pub union XEvent {
     pub xkeymap: XKeymapEvent,
     pub xgeneric: XGenericEvent,
     pub xcookie: XGenericEventCookie,
-    pub pad: [::std::os::raw::c_long; 24usize],
+    pub pad: [c_long; 24usize],
 }

--- a/src/ffi/ffi.rs
+++ b/src/ffi/ffi.rs
@@ -1,4 +1,4 @@
-use std::os::raw::{c_char, c_int, c_ulong, c_uint, c_long};
+use core::ffi::{c_char, c_int, c_long, c_uint, c_ulong};
 
 use super::events::XEvent;
 
@@ -23,7 +23,7 @@ pub type Cursor = XID;
 pub type Colormap = XID;
 pub type GContext = XID;
 pub type KeySym = XID;
-pub type XPointer = *mut ::std::os::raw::c_char;
+pub type XPointer = *mut c_char;
 
 #[cfg(target_arch = "x86_64")]
 pub type CARD32 = c_uint;
@@ -76,21 +76,21 @@ extern "C" {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct XImage {
-    pub width: ::std::os::raw::c_int,
-    pub height: ::std::os::raw::c_int,
-    pub xoffset: ::std::os::raw::c_int,
-    pub format: ::std::os::raw::c_int,
-    pub data: *mut ::std::os::raw::c_char,
-    pub byte_order: ::std::os::raw::c_int,
-    pub bitmap_unit: ::std::os::raw::c_int,
-    pub bitmap_bit_order: ::std::os::raw::c_int,
-    pub bitmap_pad: ::std::os::raw::c_int,
-    pub depth: ::std::os::raw::c_int,
-    pub bytes_per_line: ::std::os::raw::c_int,
-    pub bits_per_pixel: ::std::os::raw::c_int,
-    pub red_mask: ::std::os::raw::c_ulong,
-    pub green_mask: ::std::os::raw::c_ulong,
-    pub blue_mask: ::std::os::raw::c_ulong,
+    pub width: c_int,
+    pub height: c_int,
+    pub xoffset: c_int,
+    pub format: c_int,
+    pub data: *mut c_char,
+    pub byte_order: c_int,
+    pub bitmap_unit: c_int,
+    pub bitmap_bit_order: c_int,
+    pub bitmap_pad: c_int,
+    pub depth: c_int,
+    pub bytes_per_line: c_int,
+    pub bits_per_pixel: c_int,
+    pub red_mask: c_ulong,
+    pub green_mask: c_ulong,
+    pub blue_mask: c_ulong,
     pub obdata: XPointer
 }
 

--- a/src/ffi/mouse.rs
+++ b/src/ffi/mouse.rs
@@ -1,4 +1,4 @@
-use std::os::raw::{c_int, c_uint};
+use core::ffi::{c_int, c_uint};
 
 use crate::ffi::*;
 

--- a/src/ffi/shm.rs
+++ b/src/ffi/shm.rs
@@ -1,4 +1,4 @@
-use std::os::raw::{c_uint, c_int, c_char, c_ulong};
+use core::ffi::{c_uint, c_int, c_char, c_ulong};
 
 use crate::ffi::*;
 

--- a/src/ffi/xrandr.rs
+++ b/src/ffi/xrandr.rs
@@ -1,4 +1,4 @@
-use libc::c_int;
+use core::ffi::c_int;
 
 use crate::ffi::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,8 @@
 
 
 
-use std::ffi::{CString, c_char};
+use core::ffi::c_char;
+use std::ffi::CString;
 
 pub mod ffi;
 pub use ffi::{Rgb8, Bgr8};

--- a/src/shm.rs
+++ b/src/shm.rs
@@ -30,6 +30,7 @@
 //!
 
 
+use core::ffi::{c_char, c_void};
 use crate::{Display, Image, ffi::{*, constants::*}};
 use std::pin::Pin;
 
@@ -68,7 +69,7 @@ impl<'a> SharedSession<'a> {
 }
 impl<'a> Drop for SharedSession<'a> {
     fn drop(&mut self) {
-        use libc::{shmdt, shmctl, shmid_ds, IPC_RMID, c_void};
+        use libc::{shmdt, shmctl, shmid_ds, IPC_RMID};
         unsafe {
             XShmDetach(self.display.connection, self.shminfo.as_ref().get_ref());
             shmdt((*self.shminfo).shmaddr as *const c_void);
@@ -139,7 +140,6 @@ impl<'a> ShmBuilder<'a> {
         unsafe {
             use libc::{shmget, shmat};
             use libc::{IPC_PRIVATE, IPC_CREAT};
-            use libc::{c_char, c_void};
 
             if XShmQueryExtension(self.display.connection) {
                 let vis = XDefaultVisual(self.display.connection, 0);


### PR DESCRIPTION
The codebase was using three different crates for C types.
It seems like `core::ffi` seems to be the definitive source for these so I changed all other C type references to use `core::ffi`
